### PR TITLE
cuda-nsight v12.9.79

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Ignore all files and folders in root
 *
 !/conda-forge.yml
+!/abs.yaml
 
 # Don't ignore any files/folders if the parent folder is 'un-ignored'
 # This also avoids warnings when adding an already-checked file with an ignored parent.

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,9 @@
+# build_parameters:
+#   - "--suppress-variables"
+#   #- "--skip-existing"
+#   - "--error-overlinking"
+
+# staging_channel_upload_target: ctk-12.9-build-4
+
+# channels:
+#   - https://staging.continuum.io/pbp/ctk-12.9-build-4

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,12 +35,14 @@ about:
   license_file: LICENSE
   license: LicenseRef-NVIDIA-End-User-License-Agreement
   license_url: https://docs.nvidia.com/cuda/eula/index.html
+  license_family: Other
   summary: A unified CPU plus GPU IDE for developing CUDA applications
   description: |
     NVIDIA Nsight Eclipse Edition is a unified CPU plus GPU integrated
     development environment (IDE) for developing CUDA applications for
     the x86, POWER and ARM platforms.
   doc_url: https://developer.nvidia.com/nsight-eclipse-edition
+  dev_url: https://developer.nvidia.com/nsight-eclipse-edition
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
cuda-nsight 12.9.79

**Destination channel:** defaults

### Links

- [PKG-12773](https://anaconda.atlassian.net/browse/PKG-12773) 
- [CUDA 12.9 release notes](https://docs.nvidia.com/cuda/archive/12.9.1/cuda-toolkit-release-notes/index.html) for list of packages, version numbers, etc.

### Explanation of changes:

- CUDA 12.9 release
- Added `abs.yaml` for possible use of staging channels in future builds



[PKG-12773]: https://anaconda.atlassian.net/browse/PKG-12773?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ